### PR TITLE
Fix: Handle Craft Links with Custom Domains by Implementing getCraftSlug Function

### DIFF
--- a/components/NotePost.js
+++ b/components/NotePost.js
@@ -1,9 +1,10 @@
 import BLOG from '@/blog.config.js'
 import Link from 'next/link'
 import ImageFallback from './Common/ImageFallback.js'
+import getCraftSlug from '@/lib/getCraftSlug'
 
 const NotePost = ({ note }) => {
-  const craftSlug = note.url.slice(23)
+  const craftSlug = getCraftSlug(note.url)
   return (
     <Link
       passHref
@@ -26,3 +27,4 @@ const NotePost = ({ note }) => {
 }
 
 export default NotePost
+

--- a/lib/getBlocksMaps.js
+++ b/lib/getBlocksMaps.js
@@ -1,8 +1,9 @@
 import BLOG from '@/blog.config'
+import getCraftSlug from '@/lib/getCraftSlug'
 
 // 从 Config 页面的 API 获取两个表格的内容, 并处理成两个 json 返回给 htmlrewrite.js
 export async function getBlocksMaps() {
-  const craftConfigSecret = BLOG.craftConfigShareUrl.slice(23)
+  const craftConfigSecret = getCraftSlug(BLOG.craftConfigShareUrl)
   const craftConfigApiUrl = 'https://www.craft.do/api/share/' + craftConfigSecret
   const init = {
     headers: {
@@ -150,3 +151,4 @@ function getSiteConfigObj(mapJson, configColumId, valueColumId) {
   })
   return siteConfigObj
 }
+

--- a/lib/getCraftSlug.js
+++ b/lib/getCraftSlug.js
@@ -1,0 +1,24 @@
+/**
+ * Extracts the ID from a given Craft link.
+ * @param {string} link - The Craft link.
+ * @returns {string} - The extracted ID.
+ * @throws Will throw an error if the link format is invalid.
+ */
+const getCraftSlug = (link) => {
+    const patterns = [
+      /^https:\/\/www\.craft\.me\/s\/(.+)$/,
+      /^https:\/\/www\.craft\.do\/s\/(.+)$/,
+      /^https:\/\/.+\.craft\.me\/(.+)$/
+    ];
+  
+    for (const pattern of patterns) {
+      const match = link.match(pattern);
+      if (match) {
+        return match[1];
+      }
+    }
+  
+    throw new Error("Invalid link format");
+  };
+  
+  export default getCraftSlug;  


### PR DESCRIPTION
The Craft application used for displaying notes has introduced a feature allowing users to share links with custom domains. Previously, links followed the pattern "https://www.craft.do/s/" with a 23-character slug, which was sliced to extract the necessary ID. However, this approach fails with the new custom domain links, causing issues in preview images and other functionalities. This affects new users configuring the Craft settings for the project as well.

To address this problem, I have implemented a `getCraftSlug` function in the `lib` directory. This function correctly extracts the slug from both the old and new link formats, ensuring the application functions correctly without errors. This change ensures that both legacy and new links are handled seamlessly, maintaining the integrity of the application for all users.
